### PR TITLE
flakes: align with neovim core, add additional flake outputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1606424373,
-        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1609246779,
@@ -31,78 +15,26 @@
         "type": "github"
       }
     },
-    "gitignore": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1594969032,
-        "narHash": "sha256-nbZfz02QoVe1yYK7EtCV7wMi4VdHzZEoPg20ZSDo9to=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "c4662e662462e7bf3c2a968483478a665d00e717",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "neovim-nightly": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1609706001,
-        "narHash": "sha256-mt5e0CWYncJGNQlO318cotv0vx5LOUxc12taFOf71i0=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "a1ed941a7881122fda2fd48e71e890ed55e4d08e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "neovim",
-        "repo": "neovim",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1609574679,
-        "narHash": "sha256-PiNoISdoXCtRjdHapgDOwOYxaAdtRTked90hubk+x0Q=",
+        "lastModified": 1614029319,
+        "narHash": "sha256-PXu4Vf05f3E2vpl7/Iop/O+gw655O3SONYVFxbl0kuc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2080afd039999a58d60596d04cefb32ef5fcc2a2",
+        "rev": "c7d0dbe094c988209edac801eb2a0cc21aa498d8",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1609317732,
-        "narHash": "sha256-kMRAPslPafHy4J5jFYzaZ39tlCcWb07qZ2KN9GDQws4=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "7a2bec0576d2b7a91e2bbf0ad31e80f08a0b7af3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "gitignore": "gitignore",
-        "neovim-nightly": "neovim-nightly",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,81 @@
 {
-  description = "Neovim nightly overlay";
+  description = "Neovim flake";
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-  inputs.flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
-  inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.neovim-nightly = { url = "github:neovim/neovim"; flake = false; };
-  inputs.gitignore = { url = "github:hercules-ci/gitignore.nix"; flake = false;};
-  inputs.pre-commit-hooks= { url = "github:cachix/pre-commit-hooks.nix"; flake = false;};
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
 
-  outputs = { self, ... }@inputs:
-    with inputs;
+  outputs = { self, nixpkgs, flake-utils }:
     {
       overlay = final: prev:
         let
-          pkgs = inputs.nixpkgs.legacyPackages.${prev.system};
+          pkgs = nixpkgs.legacyPackages.${prev.system};
         in
-        {
-          neovim-nightly = pkgs.neovim-unwrapped.overrideAttrs (
-            old: {
-              pname = "neovim-nightly";
-              version = "master";
-              src = inputs.neovim-nightly;
+        rec {
+          neovim = pkgs.neovim-unwrapped.overrideAttrs (oa: {
+            version = "master";
+            src = ../.;
 
-              buildInputs = old.buildInputs ++ [ pkgs.tree-sitter ];
-            }
-          );
+            buildInputs = oa.buildInputs ++ ([
+              pkgs.tree-sitter
+            ]);
+
+            cmakeFlags = oa.cmakeFlags ++ [
+              "-DUSE_BUNDLED=OFF"
+            ];
+          });
+
+          # a development binary to help debug issues
+          neovim-debug = let
+            stdenv = pkgs.stdenvAdapters.keepDebugInfo (if pkgs.stdenv.isLinux then pkgs.llvmPackages_latest.stdenv else pkgs.stdenv);
+          in
+            pkgs.enableDebugging ((neovim.override {
+            lua = pkgs.enableDebugging pkgs.luajit;
+            inherit stdenv;
+          }).overrideAttrs (oa: {
+            cmakeBuildType = "Debug";
+            cmakeFlags = oa.cmakeFlags ++ [
+              "-DMIN_LOG_LEVEL=0"
+            ];
+
+            disallowedReferences = [];
+          }));
+
+          # for neovim developers, very slow
+          # brings development tools as well
+          neovim-developer =
+            let
+              lib = nixpkgs.lib;
+              pythonEnv = pkgs.python3;
+              luacheck = pkgs.luaPackages.luacheck;
+            in
+            (neovim-debug.override ({ doCheck = pkgs.stdenv.isLinux; })).overrideAttrs (oa: {
+              cmakeFlags = oa.cmakeFlags ++ [
+                "-DLUACHECK_PRG=${luacheck}/bin/luacheck"
+                "-DMIN_LOG_LEVEL=0"
+                "-DENABLE_LTO=OFF"
+                "-DUSE_BUNDLED=OFF"
+              ] ++ pkgs.stdenv.lib.optionals pkgs.stdenv.isLinux [
+                # https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
+                # https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports
+                "-DCLANG_ASAN_UBSAN=ON"
+              ];
+
+              nativeBuildInputs = oa.nativeBuildInputs ++ (with pkgs; [
+                pythonEnv
+                include-what-you-use # for scripts/check-includes.py
+                jq # jq for scripts/vim-patch.sh -r
+                doxygen
+              ]);
+
+              shellHook = oa.shellHook + ''
+                export NVIM_PYTHON_LOG_LEVEL=DEBUG
+                export NVIM_LOG_FILE=/tmp/nvim.log
+                export ASAN_OPTIONS="log_path=./test.log:abort_on_error=1"
+                export UBSAN_OPTIONS=print_stacktrace=1
+              '';
+            });
         };
     } //
     flake-utils.lib.eachDefaultSystem (system:
@@ -34,9 +85,22 @@
           inherit system;
         };
       in
-      {
-        defaultPackage = pkgs.neovim-nightly;
-        devShell = import ./shell.nix { inherit pkgs inputs; };
+      rec {
+
+        packages = with pkgs; {
+          inherit neovim neovim-debug neovim-developer;
+        };
+
+        defaultPackage = pkgs.neovim;
+
+        apps = {
+          nvim = flake-utils.lib.mkApp { drv = pkgs.neovim; name = "nvim"; };
+          nvim-debug = flake-utils.lib.mkApp { drv = pkgs.neovim-debug; name = "nvim"; };
+        };
+
+        defaultApp = apps.nvim;
+
+        devShell = pkgs.neovim-developer;
       }
     );
 }


### PR DESCRIPTION
Closes #89 (ish)

Right now asan doesn't work on darwin, but otherwise I think this is an improvement? Not sure if we want to wrap neovim's flake or just follow it.