### PR TITLE
treewide: cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,38 +1,18 @@
 name: "Build"
 
 on:
-  # Build on push to master
   push:
-    branches:
-      - master
-
-  # Build on internal pull requests
   pull_request:
-
-  # Allow to trigger for external PRs
   workflow_dispatch:
-
-  # Also run regularly because pushes initiated by GitHub Actions don't
-  # trigger the above events.
-  schedule:
-    # every day at 8am UTC
-    - cron: '10 8 * * *'
-
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-10.15, ubuntu-latest]
+    runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v16
-      with:
-        extra_nix_config: |
-          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v3.0.2
+    - uses: cachix/install-nix-action@v17
     - uses: cachix/cachix-action@v10
       with:
         name: nix-community
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - run: nix build 
+    - run: nix build

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -5,33 +5,18 @@ on:
     # every day at 8am UTC
     - cron: '0 8 * * *'
   workflow_dispatch:
-
 jobs:
-  update-dependencies:
+  updates:
+    name: "Update the flake.lock"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v16
+    - uses: actions/checkout@v3.0.2
       with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-3.0pre20201007_5257a25/install
-        extra_nix_config: |
-          experimental-features = nix-command flakes
-    - run: nix flake update --recreate-lock-file
-    - uses: cachix/cachix-action@v10
-      with:
-        name: nix-community
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-        # Only needed for private caches
-        #authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-        # - run: nix build
-    # - run: nix-shell --run "echo OK"
-    #- name: Create Pull Request
-    #  uses: peter-evans/create-pull-request@v3
-    #  with:
-    #    token: "${{ secrets.GITHUB_TOKEN }}"
-    #    commit-message: "[automation] update flake dependencies"
-    #    title: "[automation] update flake dependencies"
-    #    branch: "automation/update-flake-dependencies"
-    - uses: stefanzweifel/git-auto-commit-action@v4.11.0
-      with:
-        commit_message: "[automation] update flake dependencies"
+        fetch-depth: 0
+    - uses: cachix/install-nix-action@v17
+    - name : 'flake.lock: Update'
+      run: |
+        git config user.name 'github-actions'
+        git config user.email 'action@github.com'
+        nix flake update --commit-lock-file
+        git push

--- a/flake.lock
+++ b/flake.lock
@@ -56,16 +56,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1663761423,
-        "narHash": "sha256-bDLXl2BVq7eIQz/8CduZI1SLyhG9u/CrckHd6f7bwPE=",
+        "lastModified": 1663819708,
+        "narHash": "sha256-nKyJpwzGoV+5BNLHlrEMawsDxR1i6WOXqTcHWrWE8y4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d6490a0bd9dfb298fcd8382d3363b86870dc7340",
+        "rev": "f586d35a11ec07ced41d9d62c125c6ca0006141f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,20 +2,23 @@
   description = "Neovim flake";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
     neovim-flake.url = "github:neovim/neovim?dir=contrib";
     neovim-flake.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = { self, nixpkgs, neovim-flake, ... }:
-    rec {
-      inherit (neovim-flake) packages defaultPackage apps defaultApp devShell;
-      overlay = final: prev: rec {
+    let forAllSystems = (nixpkgs.lib.genAttrs [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ]); in
+    {
+      packages = forAllSystems (system: { inherit (neovim-flake.packages.${system}) default neovim; });
+      defaultPackage = forAllSystems (system: neovim-flake.packages.${system}.default);
+      overlay = final: prev: {
         neovim-unwrapped = neovim-flake.packages.${prev.system}.neovim;
         neovim-nightly = neovim-flake.packages.${prev.system}.neovim;
-        neovim-debug = neovim-flake.packages.${prev.system}.neovim-debug;
-        neovim-developer = neovim-flake.packages.${prev.system}.neovim-developer;
+      };
+      herculesCI = {
+        ciSystems = [ "x86_64-linux" "aarch64-linux" ]; # These are the only systems avaiable currently for our Hercules-CI infra.
       };
     };
 }


### PR DESCRIPTION
- Now building CI for `aarch64-linux`
- No longer providing development packages and devshells