### PR TITLE
ci: use cachix auth token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,5 +27,5 @@ jobs:
     - uses: cachix/cachix-action@v12
       with:
         name: nix-community
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix build 


### PR DESCRIPTION
Tokens are easier to rotate than signing keys