### PR TITLE
feat: move neovim flake into the overlay itself

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -98,21 +98,33 @@
     "neovim-flake": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "neovim-src": "neovim-src",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "dir": "contrib",
-        "lastModified": 1713392591,
-        "narHash": "sha256-k7d4HX+HZgRGy6bGtZ5VjuhCrrBd3PoYvdwbeT34Mrs=",
+        "lastModified": 1,
+        "narHash": "sha256-7X/tWr/FVnUaGFodeU51ViNGhNjW6ZX+yl3vFJqFQK0=",
+        "path": "./neovim",
+        "type": "path"
+      },
+      "original": {
+        "path": "./neovim",
+        "type": "path"
+      }
+    },
+    "neovim-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1713452278,
+        "narHash": "sha256-IfCpwH/cs7MHhsCisnRXjHLDNsf6ZEGKwJup4ZVi740=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "562719033ec8bec9f6d56c166b9aef13f8a50a96",
+        "rev": "f1dfe32bf5552197e0068298b0527526a4f918b1",
         "type": "github"
       },
       "original": {
-        "dir": "contrib",
         "owner": "neovim",
         "repo": "neovim",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     flake-parts = { url = "github:hercules-ci/flake-parts"; inputs.nixpkgs-lib.follows = "nixpkgs"; };
     hercules-ci-effects = { url = "github:hercules-ci/hercules-ci-effects"; inputs.nixpkgs.follows = "nixpkgs"; };
     flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
-    neovim-flake = { url = "github:neovim/neovim?dir=contrib"; inputs.nixpkgs.follows = "nixpkgs"; };
+    neovim-flake = { url = "path:./neovim"; inputs.nixpkgs.follows = "nixpkgs"; };
   };
 
   outputs = inputs:

--- a/neovim/flake.nix
+++ b/neovim/flake.nix
@@ -1,0 +1,166 @@
+{
+  description = "Neovim flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    neovim-src.url = "github:neovim/neovim";
+    neovim-src.flake = false;
+  };
+
+  outputs = { self, nixpkgs, flake-utils, neovim-src }:
+    let
+      inherit (builtins)
+        elemAt
+        foldl'
+        mapAttrs
+        match
+        readFile
+        ;
+      inherit (nixpkgs.lib)
+        const
+        flip
+        pipe
+        remove
+        splitString
+        toLower
+        ;
+    in
+    {
+      overlay = final: prev: {
+
+        neovim = (final.neovim-unwrapped.override {
+          treesitter-parsers = pipe "${neovim-src}/cmake.deps/deps.txt" [
+            readFile
+            (splitString "\n")
+            (map (match "TREESITTER_([A-Z_]+)_(URL|SHA256)[[:space:]]+([^[:space:]]+)[[:space:]]*"))
+            (remove null)
+            (flip foldl' { }
+              (acc: matches:
+                let
+                  lang = toLower (elemAt matches 0);
+                  type = toLower (elemAt matches 1);
+                  value = elemAt matches 2;
+                in
+                acc // {
+                  ${lang} = acc.${lang} or { } // {
+                    ${type} = value;
+                  };
+                }))
+            (mapAttrs (const final.fetchurl))
+            (self: self // {
+              markdown = final.stdenv.mkDerivation {
+                inherit (self.markdown) name;
+                src = self.markdown;
+                installPhase = ''
+                  mv tree-sitter-markdown $out
+                '';
+              };
+            })
+          ];
+        }).overrideAttrs (oa: rec {
+          version = self.shortRev or "dirty";
+          src = "${neovim-src}";
+          preConfigure = oa.preConfigure or "" + ''
+            sed -i cmake.config/versiondef.h.in -e 's/@NVIM_VERSION_PRERELEASE@/-dev-${version}/'
+          '';
+          nativeBuildInputs = oa.nativeBuildInputs ++ [
+            final.libiconv
+          ];
+        });
+
+        # a development binary to help debug issues
+        neovim-debug = let
+          stdenv = if final.stdenv.isLinux then
+            final.llvmPackages_latest.stdenv
+          else
+            final.stdenv;
+        in (final.neovim.override {
+          lua = final.luajit;
+          inherit stdenv;
+        }).overrideAttrs (oa: {
+
+          dontStrip = true;
+          NIX_CFLAGS_COMPILE = " -ggdb -Og";
+
+          cmakeBuildType = "Debug";
+
+          disallowedReferences = [ ];
+        });
+
+        # for neovim developers, beware of the slow binary
+        neovim-developer = let inherit (final.luaPackages) luacheck;
+        in final.neovim-debug.overrideAttrs (oa: {
+          cmakeFlags = oa.cmakeFlags ++ [
+            "-DLUACHECK_PRG=${luacheck}/bin/luacheck"
+            "-DENABLE_LTO=OFF"
+          ] ++ final.lib.optionals final.stdenv.isLinux [
+            # https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
+            # https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports
+            "-DENABLE_ASAN_UBSAN=ON"
+          ];
+          doCheck = final.stdenv.isLinux;
+        });
+      };
+    } // flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          overlays = [ self.overlay ];
+          inherit system;
+        };
+
+        lua = pkgs.lua5_1;
+
+        pythonEnv = pkgs.python3.withPackages (ps: [
+          ps.msgpack
+        ]);
+      in {
+        packages = with pkgs; {
+          default = neovim;
+          inherit neovim neovim-debug neovim-developer;
+        };
+
+        checks = {
+          shlint = pkgs.runCommand "shlint" {
+            nativeBuildInputs = [ pkgs.shellcheck ];
+            preferLocalBuild = true;
+          } "make -C ${neovim-src} shlint > $out";
+        };
+
+        # kept for backwards-compatibility
+        defaultPackage = pkgs.neovim;
+
+        devShells = {
+          default = pkgs.neovim-developer.overrideAttrs (oa: {
+
+            buildInputs = with pkgs;
+              oa.buildInputs ++ [
+                lua.pkgs.luacheck
+                sumneko-lua-language-server
+                pythonEnv
+                include-what-you-use # for scripts/check-includes.py
+                jq # jq for scripts/vim-patch.sh -r
+                shellcheck # for `make shlint`
+              ];
+
+            nativeBuildInputs = with pkgs;
+              oa.nativeBuildInputs ++ [
+                clang-tools # for clangd to find the correct headers
+              ];
+
+            shellHook = oa.shellHook + ''
+              export NVIM_PYTHON_LOG_LEVEL=DEBUG
+              export NVIM_LOG_FILE=/tmp/nvim.log
+              export ASAN_SYMBOLIZER_PATH=${pkgs.llvm_18}/bin/llvm-symbolizer
+
+              # ASAN_OPTIONS=detect_leaks=1
+              export ASAN_OPTIONS="log_path=./test.log:abort_on_error=1"
+
+              # for treesitter functionaltests
+              mkdir -p runtime/parser
+              cp -f ${pkgs.vimPlugins.nvim-treesitter.builtGrammars.c}/parser runtime/parser/c.so
+            '';
+          });
+        };
+      });
+}


### PR DESCRIPTION
Attempts to move the Neovim nix flake into this overlay. See https://github.com/neovim/neovim/pull/28305#issuecomment-2052066183. I'm marking this as draft because I am not confident enough in my Nix knowledge, but in my local testing this seemed to work well. The sub-flake importing followed solutions discussed in https://github.com/NixOS/nix/issues/3978, though it has its caveats as mentioned over there. Still, I think this may be a fine solution, and I will try to be quick to amend the PR if anything needs a change :+1:

EDIT: I think this is ready for review. It seems to work fine in my configuration. And I believe the drawbacks mentioned above are not applicable here.

Note that the flake copied over here differs slightly from the original Neovim flake in that it pulls in
```nix
{
    neovim-src.url = "github:neovim/neovim";
    neovim-src.flake = false;
}
```
because it obviously can no longer use relative paths to access the files in the repo.