### PR TITLE
feat: move neovim flake into the overlay itself

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,46 +16,6 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1714641030,
-        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "hercules-ci-effects",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-parts",
-        "type": "indirect"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -74,45 +34,17 @@
         "type": "github"
       }
     },
-    "hercules-ci-effects": {
-      "inputs": {
-        "flake-parts": "flake-parts_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
+    "neovim-src": {
+      "flake": false,
       "locked": {
-        "lastModified": 1713898448,
-        "narHash": "sha256-6q6ojsp/Z9P2goqnxyfCSzFOD92T3Uobmj8oVAicUOs=",
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "rev": "c0302ec12d569532a6b6bd218f698bc402e93adc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "type": "github"
-      }
-    },
-    "neovim-flake": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "dir": "contrib",
-        "lastModified": 1715815279,
-        "narHash": "sha256-Pf7ZlqPnr195NZb5ADzMVsXurPMjRZ+JMXf6JxvXArE=",
+        "lastModified": 1716314568,
+        "narHash": "sha256-g0vgcHRbrNuSPPieyv07TlUXahYbDbyyKJrgLpl6aa8=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "9ca81b025990911c2a0dbda92af39ba84983bac3",
+        "rev": "879d17ea8d62c199ea0c91c5f37a4f25495be7ce",
         "type": "github"
       },
       "original": {
-        "dir": "contrib",
         "owner": "neovim",
         "repo": "neovim",
         "type": "github"
@@ -120,11 +52,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715774670,
-        "narHash": "sha256-iJYnKMtLi5u6hZhJm94cRNSDG5Rz6ZzIkGbhPFtDRm0=",
+        "lastModified": 1716220750,
+        "narHash": "sha256-Lhhrd1ZBNXCbUupWGq6gRPIy1qMKEdcAXcjnwgVqe/U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3fcfcfabd01b947a1e4f36622bbffa3985bdac6",
+        "rev": "641daa314d5bc1bca4b345da8eb08a130b109c79",
         "type": "github"
       },
       "original": {
@@ -137,9 +69,8 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
-        "hercules-ci-effects": "hercules-ci-effects",
-        "neovim-flake": "neovim-flake",
+        "flake-utils": "flake-utils",
+        "neovim-src": "neovim-src",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,49 +3,225 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-parts = { url = "github:hercules-ci/flake-parts"; inputs.nixpkgs-lib.follows = "nixpkgs"; };
-    hercules-ci-effects = { url = "github:hercules-ci/hercules-ci-effects"; inputs.nixpkgs.follows = "nixpkgs"; };
-    flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
-    neovim-flake = { url = "github:neovim/neovim?dir=contrib"; inputs.nixpkgs.follows = "nixpkgs"; };
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    neovim-src = {
+      url = "github:neovim/neovim";
+      flake = false;
+    };
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = inputs:
-    inputs.flake-parts.lib.mkFlake { inherit inputs; } ({ config, ... }: {
-      systems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-      ];
-
-      imports = [
-        inputs.flake-parts.flakeModules.easyOverlay
-        inputs.hercules-ci-effects.flakeModule
-      ];
-
-      perSystem = { inputs', system, config, lib, pkgs, ... }: {
-        packages = {
-          neovim = inputs'.neovim-flake.packages.neovim // (lib.optionalAttrs pkgs.stdenv.isDarwin { ignoreFailure = true; });
-          default = config.packages.neovim;
+  outputs =
+    {
+      self,
+      nixpkgs,
+      neovim-src,
+      flake-utils,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          overlays = [ self.overlays.default ];
+          inherit system;
         };
-        overlayAttrs = lib.genAttrs [ "neovim-unwrapped" "neovim-nightly" ] (_: config.packages.neovim);
-      };
 
-      flake = {
-        defaultPackage = inputs.nixpkgs.lib.genAttrs config.systems (system: inputs.self.packages.${system}.default);
-        overlay = inputs.self.overlays.default;
-      };
+        lua = pkgs.lua5_1;
 
-      hercules-ci.flake-update = {
-        enable = true;
-        baseMerge.enable = true;
-        baseMerge.method = "rebase";
-        autoMergeMethod = "rebase";
-        # Update everynight at midnight
-        when = {
-          hour = [ 0 ];
-          minute = 0;
+        pythonEnv = pkgs.python3.withPackages (ps: [ ps.msgpack ]);
+      in
+      {
+        packages = with pkgs; {
+          default = neovim;
+          inherit neovim neovim-debug neovim-developer;
         };
-      };
-    });
+
+        checks = {
+          shlint = pkgs.runCommand "shlint" {
+            nativeBuildInputs = [ pkgs.shellcheck ];
+            preferLocalBuild = true;
+          } "make -C ${neovim-src} shlint > $out";
+        };
+
+        devShells = {
+          default = pkgs.neovim-developer.overrideAttrs (oa: {
+
+            buildInputs =
+              with pkgs;
+              oa.buildInputs
+              ++ [
+                lua.pkgs.luacheck
+                sumneko-lua-language-server
+                pythonEnv
+                include-what-you-use # for scripts/check-includes.py
+                jq # jq for scripts/vim-patch.sh -r
+                shellcheck # for `make shlint`
+              ];
+
+            nativeBuildInputs =
+              with pkgs;
+              oa.nativeBuildInputs
+              ++ [
+                clang-tools # for clangd to find the correct headers
+              ];
+
+            shellHook =
+              oa.shellHook
+              + ''
+                export NVIM_PYTHON_LOG_LEVEL=DEBUG
+                export NVIM_LOG_FILE=/tmp/nvim.log
+                export ASAN_SYMBOLIZER_PATH=${pkgs.llvm_18}/bin/llvm-symbolizer
+
+                # ASAN_OPTIONS=detect_leaks=1
+                export ASAN_OPTIONS="log_path=./test.log:abort_on_error=1"
+
+                # for treesitter functionaltests
+                mkdir -p runtime/parser
+                cp -f ${pkgs.vimPlugins.nvim-treesitter.builtGrammars.c}/parser runtime/parser/c.so
+              '';
+          });
+        };
+      }
+    )
+    // {
+      overlays.default =
+        final: prev:
+        let
+          inherit (final) lib;
+          deps = lib.pipe "${neovim-src}/cmake.deps/deps.txt" [
+            builtins.readFile
+            (lib.splitString "\n")
+            (map (builtins.match "([A-Z0-0_]+)_(URL|SHA256)[[:space:]]+([^[:space:]]+)[[:space:]]*"))
+            (lib.remove null)
+            (lib.flip builtins.foldl' { } (
+              acc: matches:
+              let
+                name = lib.toLower (builtins.elemAt matches 0);
+                key = lib.toLower (builtins.elemAt matches 1);
+                value = lib.toLower (builtins.elemAt matches 2);
+              in
+              acc
+              // {
+                ${name} = acc.${name} or { } // {
+                  ${key} = value;
+                };
+              }
+            ))
+            (builtins.mapAttrs (lib.const final.fetchurl))
+          ];
+          tree-sitter = final.tree-sitter.override (_: {
+            rustPlatform = final.rustPlatform // {
+              buildRustPackage =
+                args:
+                final.rustPlatform.buildRustPackage (
+                  args
+                  // {
+                    src = deps.treesitter;
+                    cargoHash = "sha256-U2YXpNwtaSSEftswI0p0+npDJqOq5GqxEUlOPRlJGmQ=";
+                  }
+                );
+            };
+          });
+
+          treesitter-parsers =
+            let
+              grammars = lib.filterAttrs (name: _: lib.hasPrefix "treesitter_" name) deps;
+              parsers = lib.mapAttrs' (
+                name: value: lib.nameValuePair (lib.removePrefix "treesitter_" name) { src = value; }
+              ) grammars;
+            in
+            parsers
+            // {
+              markdown = parsers.markdown // {
+                location = "tree-sitter-markdown";
+              };
+              markdown-inline = parsers.markdown // {
+                language = "markdown_inline";
+                location = "tree-sitter-markdown-inline";
+              };
+            };
+        in
+        {
+
+          neovim =
+            (final.neovim-unwrapped.override {
+              inherit tree-sitter;
+              inherit treesitter-parsers;
+              msgpack-c = final.msgpack-c.overrideAttrs (_: {
+                src = deps.msgpack;
+              });
+              gettext = final.gettext.overrideAttrs (_: {
+                src = deps.gettext;
+              });
+              libiconv = final.libiconv.overrideAttrs (_: {
+                src = deps.libiconv;
+              });
+              libuv = final.libuv.overrideAttrs (_: {
+                src = deps.libuv;
+              });
+              libvterm-neovim = final.libvterm-neovim.overrideAttrs (_: {
+                src = deps.libvterm;
+              });
+            }).overrideAttrs
+              (
+                oa:
+                let
+                  version = neovim-src.shortRev or "dirty";
+                in
+                {
+
+                  src = "${neovim-src}";
+                  preConfigure =
+                    oa.preConfigure or ""
+                    + ''
+                      sed -i cmake.config/versiondef.h.in -e 's/@NVIM_VERSION_PRERELEASE@/-dev-${version}/'
+                    '';
+                  nativeBuildInputs = oa.nativeBuildInputs ++ [ final.libiconv ];
+                }
+              );
+
+          # a development binary to help debug issues
+          neovim-debug =
+            let
+              stdenv = if final.stdenv.isLinux then final.llvmPackages_latest.stdenv else final.stdenv;
+            in
+            (final.neovim.override {
+              lua = final.luajit;
+              inherit stdenv;
+            }).overrideAttrs
+              (oa: {
+
+                dontStrip = true;
+                NIX_CFLAGS_COMPILE = " -ggdb -Og";
+
+                cmakeBuildType = "Debug";
+
+                disallowedReferences = [ ];
+              });
+
+          # for neovim developers, beware of the slow binary
+          neovim-developer =
+            let
+              inherit (final.luaPackages) luacheck;
+            in
+            final.neovim-debug.overrideAttrs (oa: {
+              cmakeFlagsArray =
+                oa.cmakeFlagsArray
+                ++ [
+                  "-DLUACHECK_PRG=${luacheck}/bin/luacheck"
+                  "-DENABLE_LTO=OFF"
+                ]
+                ++ final.lib.optionals final.stdenv.isLinux [
+                  # https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
+                  # https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports
+                  "-DENABLE_ASAN_UBSAN=ON"
+                ];
+              doCheck = final.stdenv.isLinux;
+            });
+        };
+    };
 }


### PR DESCRIPTION
Maintaing the flake in the official neovim repository became too much of a burden so we are moving it out to a nix-community repository.

This is the opportunity to do more and add automation so that the neovim nix overlay doesnt ever break !


This became a pressing issue so even though this is not perfect yet, let's merge and iterate. 

Note that maintainers are welcome to help with this repo, I would rather focus on nixpkgs.

Kudos to @ribru17 @willruggiano for their help. 

cc my neovim mates @gaetanlepage @mrcjkb and @Kranzes the maintainer
