### PR TITLE
feat: fixed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ If you are using flakes to configure your system, add to your nixpkgs overlays a
 
 ```nix
 {
-  inputs.neovim-nightly-overlay.url = "github:nix-community/neovim-nightly-overlay";
+  inputs = {
+    neovim-nightly-overlay.url = "github:nix-community/neovim-nightly-overlay";
+  };
+
   outputs = { self, ... }@inputs:
     let
       overlays = [
@@ -25,10 +28,11 @@ If you are using flakes to configure your system, add to your nixpkgs overlays a
     in
       homeConfigurations = {
         macbook-pro = inputs.home-manager.lib.homeManagerConfiguration {
-          configuration = { pkgs, ... }:
+          modules = [
             {
               nixpkgs.overlays = overlays;
             };
+          ];
         };
       };
 }


### PR DESCRIPTION
I closed #497 by error.
cc @DockterTeagle 

---

The documentation had a deprecated argument in the home-manager example by using configuration, this aims to fix that by providing an example of how to fix it in the current nixos unstable branch(which at the time of writting is 24.05), through a comment.

Fixes #496 