### PR TITLE
packages/neovim: stop ignoring failure of neovim for darwin on Hercules-CI

### DIFF
--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -95,7 +95,4 @@ in
       ${oa.preConfigure}
       sed -i cmake.config/versiondef.h.in -e 's/@NVIM_VERSION_PRERELEASE@/-dev+${neovim-src.shortRev or "dirty"}/'
     '';
-
-    # libiconv is failing
-    ignoreFailure = pkgs.stdenv.isDarwin;
   })


### PR DESCRIPTION
Indeed, the package is now fixed on darwin.