### PR TITLE
Update link from unofficial nixos wiki to official one

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ Add the overlay to your home.nix (home-manager) or configuration.nix (nixos):
 
 See: https://app.cachix.org/cache/nix-community
 
-[flakes]: https://nixos.wiki/wiki/Flakes
+[flakes]: https://wiki.nixos.org/wiki/Flakes


### PR DESCRIPTION
The README references the old, unofficial NixOS wiki. This PR updates the links to point to the new official NixOS wiki source, which will be more properly maintained in the future. It's very much a Fandom wiki situation.