### PR TITLE
Avoid IFD using flake input directly

### DIFF
--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -4,12 +4,7 @@
   pkgs,
   ...
 }: let
-  src = pkgs.fetchFromGitHub {
-    owner = "neovim";
-    repo = "neovim";
-    inherit (neovim-src) rev;
-    hash = neovim-src.narHash;
-  };
+  src = neovim-src;
 
   deps = lib.pipe "${src}/cmake.deps/deps.txt" [
     builtins.readFile


### PR DESCRIPTION
This PR uses the neovim input as `src` instead of refetching it again as a FOD.

The main motivator for this change is avoiding errors when building when the option `allow-import-from-derivation` is set to `false`.
 According to [the docs](https://nix.dev/manual/nix/2.23/language/import-from-derivation):
 
> When the store path needs to be accessed, evaluation will be paused, the corresponding store object [realised](https://nix.dev/manual/nix/2.23/glossary#gloss-realise), and then evaluation resumed.
> This has performance implications: Evaluation can only finish when all required store objects are realised. Since the Nix language evaluator is sequential, it only finds store paths to read from one at a time. While realisation is always parallel, in this case it cannot be done for all required store paths at once, and is therefore much slower than otherwise.
> Realising store objects during evaluation can be disabled by setting [allow-import-from-derivation](https://nix.dev/manual/nix/2.23/command-ref/conf-file#conf-allow-import-from-derivation) to false. Without IFD it is ensured that evaluation is complete and Nix can produce a build plan before starting any realisation.

### Backwards compatibility 

I tested it locally and found no issues, but it can be a breaking change for consumers if they somehow try to access the source:

**Before**
   ```
   nix-repl> packages.x86_64-linux.neovim.src
   «derivation /nix/store/i43y4rsw4ibl239bws4vpscf6xc4ivfp-source.drv»
   ```

**After**
   ```
   nix-repl> packages.x86_64-linux.neovim.src
{
  lastModified = 1723160721;
  lastModifiedDate = "20240808234521";
  narHash = "sha256-W1Jz/sINvHUXqZIGqCoZutW7U5fDCG2xI1IcX5UjIbI=";
  outPath = "/nix/store/1q8y26lr1mrig64rvzw4xrc943nyrkzm-source";
  rev = "b9913191be0b4884d92db794e2eb92641523a415";
  shortRev = "b991319";
}
 ```