### PR TITLE
Provide working overlay for Nix 24.05

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Add the overlay to your home.nix (home-manager) or configuration.nix (nixos):
   ];
 }
 ```
-Due to some nixpkgs breaking changes if you are using NixOS 24.05 use the overlay below
+Due to some nixpkgs breaking changes if you are using NixOS 24.05 use the overlay below <br/>
+*also requires that you have the nixpkgs-unstable `nix-channel`*
 ```nix
 {
   nixpkgs.config = {

--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ Add the overlay to your home.nix (home-manager) or configuration.nix (nixos):
   ];
 }
 ```
+Due to some nixpkgs breaking changes is you are using NixOS 24.05 use the overlay below
+```nix
+{
+  nixpkgs.config = {
+    packageOverrides = pkgs: let
+      pkgs' = import <nixpkgs-unstable> {
+        inherit (pkgs) system;
+        overlays = [
+          (import (builtins.fetchTarball {
+            url = "https://github.com/nix-community/neovim-nightly-overlay/archive/master.tar.gz";
+          }))
+        ];
+      };
+    in {
+      inherit (pkgs') neovim;
+    };
+  };
+}
+```
 
 # Binary cache
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add the overlay to your home.nix (home-manager) or configuration.nix (nixos):
   ];
 }
 ```
-Due to some nixpkgs breaking changes is you are using NixOS 24.05 use the overlay below
+Due to some nixpkgs breaking changes if you are using NixOS 24.05 use the overlay below
 ```nix
 {
   nixpkgs.config = {


### PR DESCRIPTION
Due to some breaking changes the overlay provided in the readme does not work for NixOS 24.05 refer to 
https://github.com/nix-community/neovim-nightly-overlay/issues/533 and
https://github.com/nix-community/neovim-nightly-overlay/issues/547 (where I took the solution from)