### PR TITLE
reformat code with nixfmt-rfc-style; switch to treefmt

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# treewide: reformat with nixfmt-rfc-style
+3965e8f6b74a948d287e50d2fe5b208bf51595ca

--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,1 @@
-final: prev:
-(import ./flake-compat.nix).overlays.default final prev
+final: prev: (import ./flake-compat.nix).overlays.default final prev

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -3,12 +3,12 @@
     let
       lock = builtins.fromJSON (builtins.readFile ./flake.lock);
     in
-      fetchTarball {
-        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-        sha256 = lock.nodes.flake-compat.locked.narHash;
-      }
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
   )
   {
     src = ./.;
-  })
-.defaultNix
+  }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -178,7 +178,28 @@
         "git-hooks": "git-hooks",
         "hercules-ci-effects": "hercules-ci-effects",
         "neovim-src": "neovim-src",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733761991,
+        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -39,19 +39,21 @@
     ];
   };
 
-  outputs = inputs:
-    inputs.flake-parts.lib.mkFlake
-    {inherit inputs;}
-    ({config, ...}: {
-      systems = [
-        "x86_64-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "aarch64-darwin"
-      ];
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } (
+      { config, ... }:
+      {
+        systems = [
+          "x86_64-linux"
+          "x86_64-darwin"
+          "aarch64-linux"
+          "aarch64-darwin"
+        ];
 
-      imports = [
-        ./flake
-      ];
-    });
+        imports = [
+          ./flake
+        ];
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.nixpkgs-stable.follows = "nixpkgs";
     };
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   nixConfig = {

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -1,12 +1,14 @@
 {
-  perSystem = {
-    pkgs,
-    config,
-    ...
-  }: {
-    checks = {
-      # Not checking neovim-developer here as it currently failes because of memory leaks
-      inherit (config.packages) neovim;
+  perSystem =
+    {
+      pkgs,
+      config,
+      ...
+    }:
+    {
+      checks = {
+        # Not checking neovim-developer here as it currently failes because of memory leaks
+        inherit (config.packages) neovim;
+      };
     };
-  };
 }

--- a/flake/ci.nix
+++ b/flake/ci.nix
@@ -15,7 +15,7 @@ lib.optionalAttrs (inputs.hercules-ci-effects ? flakeModule) {
     autoMergeMethod = "rebase";
     # Update everynight at midnight
     when = {
-      hour = [0];
+      hour = [ 0 ];
       minute = 0;
     };
   };

--- a/flake/default.nix
+++ b/flake/default.nix
@@ -11,13 +11,24 @@
       ./overlays.nix
       ./packages
     ]
-    ++ lib.optionals (inputs.git-hooks ? flakeModule) [inputs.git-hooks.flakeModule];
+    ++ lib.optionals (inputs.git-hooks ? flakeModule) [inputs.git-hooks.flakeModule]
+    ++ lib.optionals (inputs.treefmt-nix ? flakeModule) [inputs.treefmt-nix.flakeModule];
 
   perSystem = {pkgs, ...}:
-    {
-      formatter = pkgs.alejandra;
+    lib.optionalAttrs (inputs.treefmt-nix ? flakeModule) {
+      treefmt.config = {
+        projectRootFile = "flake.nix";
+        flakeCheck = true;
+
+        programs = {
+          nixfmt = {
+            enable = true;
+            package = pkgs.nixfmt-rfc-style;
+          };
+        };
+      };
     }
     // lib.optionalAttrs (inputs.git-hooks ? flakeModule) {
-      pre-commit.settings.hooks.alejandra.enable = true;
+      pre-commit.settings.hooks.treefmt.enable = true;
     };
 }

--- a/flake/default.nix
+++ b/flake/default.nix
@@ -2,7 +2,8 @@
   inputs,
   lib,
   ...
-}: {
+}:
+{
   imports =
     [
       ./checks.nix
@@ -11,10 +12,11 @@
       ./overlays.nix
       ./packages
     ]
-    ++ lib.optionals (inputs.git-hooks ? flakeModule) [inputs.git-hooks.flakeModule]
-    ++ lib.optionals (inputs.treefmt-nix ? flakeModule) [inputs.treefmt-nix.flakeModule];
+    ++ lib.optionals (inputs.git-hooks ? flakeModule) [ inputs.git-hooks.flakeModule ]
+    ++ lib.optionals (inputs.treefmt-nix ? flakeModule) [ inputs.treefmt-nix.flakeModule ];
 
-  perSystem = {pkgs, ...}:
+  perSystem =
+    { pkgs, ... }:
     lib.optionalAttrs (inputs.treefmt-nix ? flakeModule) {
       treefmt.config = {
         projectRootFile = "flake.nix";

--- a/flake/devshells.nix
+++ b/flake/devshells.nix
@@ -1,53 +1,55 @@
 {
-  perSystem = {
-    pkgs,
-    config,
-    ...
-  }: {
-    devShells = {
-      default = pkgs.mkShell {
-        name = "neovim-developer-shell";
-        inputsFrom = [
-          config.devShells.minimal
-          config.packages.neovim-developer
-        ];
-        shellHook = ''
-          ${config.packages.neovim-developer.shellHook or ""}
-          export ASAN_SYMBOLIZER_PATH=${pkgs.llvm_18}/bin/llvm-symbolizer
-          export NVIM_PYTHON_LOG_LEVEL=DEBUG
-          export NVIM_LOG_FILE=/tmp/nvim.log
+  perSystem =
+    {
+      pkgs,
+      config,
+      ...
+    }:
+    {
+      devShells = {
+        default = pkgs.mkShell {
+          name = "neovim-developer-shell";
+          inputsFrom = [
+            config.devShells.minimal
+            config.packages.neovim-developer
+          ];
+          shellHook = ''
+            ${config.packages.neovim-developer.shellHook or ""}
+            export ASAN_SYMBOLIZER_PATH=${pkgs.llvm_18}/bin/llvm-symbolizer
+            export NVIM_PYTHON_LOG_LEVEL=DEBUG
+            export NVIM_LOG_FILE=/tmp/nvim.log
 
-          # ASAN_OPTIONS=detect_leaks=1
-          export ASAN_OPTIONS="log_path=./test.log:abort_on_error=1"
+            # ASAN_OPTIONS=detect_leaks=1
+            export ASAN_OPTIONS="log_path=./test.log:abort_on_error=1"
 
-          # for treesitter functionaltests
-          mkdir -p runtime/parser
-          cp -f ${pkgs.vimPlugins.nvim-treesitter.builtGrammars.c}/parser runtime/parser/c.so
-        '';
+            # for treesitter functionaltests
+            mkdir -p runtime/parser
+            cp -f ${pkgs.vimPlugins.nvim-treesitter.builtGrammars.c}/parser runtime/parser/c.so
+          '';
 
-        # Do not fail the hercules-ci because of this shell failing.
-        # This often happens due to neovim-developer being broken.
-        ignoreFailure = true;
-      };
+          # Do not fail the hercules-ci because of this shell failing.
+          # This often happens due to neovim-developer being broken.
+          ignoreFailure = true;
+        };
 
-      # Provide a devshell that can be used strictly for developing this flake.
-      minimal = pkgs.mkShell.override {inherit (pkgs.llvmPackages_latest) stdenv;} {
-        name = "neovim-minimal-shell";
-        inputsFrom = [
-          config.packages.default
-        ];
-        packages = with pkgs; [
-          (python3.withPackages (ps: [ps.msgpack]))
-          include-what-you-use
-          jq
-          lua-language-server
-          luajit.pkgs.luacheck
-          shellcheck
-        ];
-        shellHook = ''
-          export VIMRUNTIME=
-        '';
+        # Provide a devshell that can be used strictly for developing this flake.
+        minimal = pkgs.mkShell.override { inherit (pkgs.llvmPackages_latest) stdenv; } {
+          name = "neovim-minimal-shell";
+          inputsFrom = [
+            config.packages.default
+          ];
+          packages = with pkgs; [
+            (python3.withPackages (ps: [ ps.msgpack ]))
+            include-what-you-use
+            jq
+            lua-language-server
+            luajit.pkgs.luacheck
+            shellcheck
+          ];
+          shellHook = ''
+            export VIMRUNTIME=
+          '';
+        };
       };
     };
-  };
 }

--- a/flake/overlays.nix
+++ b/flake/overlays.nix
@@ -1,16 +1,18 @@
-{inputs, ...}: {
+{ inputs, ... }:
+{
   imports = [
     inputs.flake-parts.flakeModules.easyOverlay
   ];
 
-  perSystem = {config, ...}: {
-    overlayAttrs = {
-      inherit
-        (config.packages)
-        neovim
-        neovim-debug
-        neovim-developer
-        ;
+  perSystem =
+    { config, ... }:
+    {
+      overlayAttrs = {
+        inherit (config.packages)
+          neovim
+          neovim-debug
+          neovim-developer
+          ;
+      };
     };
-  };
 }

--- a/flake/packages/default.nix
+++ b/flake/packages/default.nix
@@ -1,30 +1,33 @@
-{inputs, ...}: {
-  perSystem = {
-    inputs',
-    system,
-    config,
-    lib,
-    pkgs,
-    ...
-  }: {
-    packages = {
-      default = config.packages.neovim;
+{ inputs, ... }:
+{
+  perSystem =
+    {
+      inputs',
+      system,
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    {
+      packages = {
+        default = config.packages.neovim;
 
-      neovim = import ./neovim.nix {
-        inherit (inputs) neovim-src;
-        inherit lib pkgs;
-      };
+        neovim = import ./neovim.nix {
+          inherit (inputs) neovim-src;
+          inherit lib pkgs;
+        };
 
-      neovim-debug = import ./neovim-debug.nix {
-        inherit (config.packages) neovim;
-        inherit pkgs;
-      };
+        neovim-debug = import ./neovim-debug.nix {
+          inherit (config.packages) neovim;
+          inherit pkgs;
+        };
 
-      neovim-developer = import ./neovim-developer.nix {
-        inherit (config.packages) neovim-debug;
-        inherit (inputs) neovim-src;
-        inherit lib pkgs;
+        neovim-developer = import ./neovim-developer.nix {
+          inherit (config.packages) neovim-debug;
+          inherit (inputs) neovim-src;
+          inherit lib pkgs;
+        };
       };
     };
-  };
 }

--- a/flake/packages/neovim-debug.nix
+++ b/flake/packages/neovim-debug.nix
@@ -4,17 +4,12 @@
   ...
 }:
 (neovim.override {
-  stdenv =
-    if pkgs.stdenv.isLinux
-    then pkgs.llvmPackages_latest.stdenv
-    else pkgs.stdenv;
+  stdenv = if pkgs.stdenv.isLinux then pkgs.llvmPackages_latest.stdenv else pkgs.stdenv;
   lua = pkgs.luajit;
-})
-.overrideAttrs (
-  oa: {
+}).overrideAttrs
+  (oa: {
     dontStrip = true;
     NIX_CFLAGES_COMPILE = " -ggdb -Og";
     cmakeBuildType = "Debug";
-    disallowedReferences = [];
-  }
-)
+    disallowedReferences = [ ];
+  })

--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -3,7 +3,8 @@
   lib,
   pkgs,
   ...
-}: let
+}:
+let
   src = neovim-src;
 
   deps = lib.pipe "${src}/cmake.deps/deps.txt" [
@@ -11,21 +12,20 @@
     (lib.splitString "\n")
     (map (builtins.match "([A-Z0-9_]+)_(URL|SHA256)[[:space:]]+([^[:space:]]+)[[:space:]]*"))
     (lib.remove null)
-    (lib.flip builtins.foldl' {}
-      (acc: matches: let
+    (lib.flip builtins.foldl' { } (
+      acc: matches:
+      let
         name = lib.toLower (builtins.elemAt matches 0);
         key = lib.toLower (builtins.elemAt matches 1);
         value = lib.toLower (builtins.elemAt matches 2);
       in
-        acc
-        // {
-          ${name} =
-            acc.${name}
-            or {}
-            // {
-              ${key} = value;
-            };
-        }))
+      acc
+      // {
+        ${name} = acc.${name} or { } // {
+          ${key} = value;
+        };
+      }
+    ))
     (builtins.mapAttrs (lib.const pkgs.fetchurl))
   ];
 
@@ -36,29 +36,29 @@
     };
   };
 
-  overrides =
-    {
-      # FIXME: this has been causing problems, see;
-      # https://github.com/nix-community/neovim-nightly-overlay/issues/538
-      # libuv = pkgs.libuv.overrideAttrs {
-      #   src = deps.libuv;
-      # };
-      lua = pkgs.luajit;
-      tree-sitter =
-        (pkgs.tree-sitter.override {
-          rustPlatform =
-            pkgs.rustPlatform
-            // {
-              buildRustPackage = args:
-                pkgs.rustPlatform.buildRustPackage (args
-                  // {
-                    version = "bundled";
-                    src = deps.treesitter;
-                    cargoHash = "sha256-gDlb+Y3E4sv9MHXvPmUFYT9DCtnFyPQsvwRaAu5Iu3M=";
-                  });
-            };
-        })
-        .overrideAttrs (oa: {
+  overrides = {
+    # FIXME: this has been causing problems, see;
+    # https://github.com/nix-community/neovim-nightly-overlay/issues/538
+    # libuv = pkgs.libuv.overrideAttrs {
+    #   src = deps.libuv;
+    # };
+    lua = pkgs.luajit;
+    tree-sitter =
+      (pkgs.tree-sitter.override {
+        rustPlatform = pkgs.rustPlatform // {
+          buildRustPackage =
+            args:
+            pkgs.rustPlatform.buildRustPackage (
+              args
+              // {
+                version = "bundled";
+                src = deps.treesitter;
+                cargoHash = "sha256-gDlb+Y3E4sv9MHXvPmUFYT9DCtnFyPQsvwRaAu5Iu3M=";
+              }
+            );
+        };
+      }).overrideAttrs
+        (oa: {
           postPatch = ''
             ${oa.postPatch}
             sed -e 's/playground::serve(.*$/println!("ERROR: web-ui is not available in this nixpkgs build; enable the webUISupport"); std::process::exit(1);/' \
@@ -66,40 +66,32 @@
           '';
         });
 
-      treesitter-parsers = let
+    treesitter-parsers =
+      let
         grammars = lib.filterAttrs (name: _: lib.hasPrefix "treesitter_" name) deps;
       in
-        lib.mapAttrs'
-        (
-          name: value:
-            lib.nameValuePair
-            (lib.removePrefix "treesitter_" name)
-            {src = value;}
-        )
-        grammars;
-    }
-    // linuxOnlyOverrides;
+      lib.mapAttrs' (
+        name: value: lib.nameValuePair (lib.removePrefix "treesitter_" name) { src = value; }
+      ) grammars;
+  } // linuxOnlyOverrides;
 in
-  (
-    pkgs.neovim-unwrapped.override
-    overrides
-  )
-  .overrideAttrs (oa: {
-    version = "nightly";
-    inherit src;
+(pkgs.neovim-unwrapped.override overrides).overrideAttrs (oa: {
+  version = "nightly";
+  inherit src;
 
-    preConfigure = ''
-      ${oa.preConfigure}
-      substituteAll cmake.config/versiondef.h.in \
-        --replace-fail '@NVIM_VERSION_PRERELEASE@' '-nightly+${neovim-src.shortRev or "dirty"}'
-    '';
+  preConfigure = ''
+    ${oa.preConfigure}
+    substituteAll cmake.config/versiondef.h.in \
+      --replace-fail '@NVIM_VERSION_PRERELEASE@' '-nightly+${neovim-src.shortRev or "dirty"}'
+  '';
 
-    buildInputs = with pkgs;
-      [
-        # TODO: remove once upstream nixpkgs updates the base drv
-        (utf8proc.overrideAttrs (_: {
-          src = deps.utf8proc;
-        }))
-      ]
-      ++ oa.buildInputs;
-  })
+  buildInputs =
+    with pkgs;
+    [
+      # TODO: remove once upstream nixpkgs updates the base drv
+      (utf8proc.overrideAttrs (_: {
+        src = deps.utf8proc;
+      }))
+    ]
+    ++ oa.buildInputs;
+})


### PR DESCRIPTION
I propose to switch to the (soon) official nix formatter

- **misc: switch to treefmt-nix + nixfmt**
- **treewide: reformat with nixfmt-rfc-style**
- **.git-blame-ignore-revs: Add treewide format**
