### PR TITLE
fix: properly replace '-dev' suffix

### DIFF
--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -81,7 +81,7 @@ in
 
   preConfigure = ''
     ${oa.preConfigure}
-    substituteAll cmake.config/versiondef.h.in \
+    substituteInPlace cmake.config/versiondef.h.in \
       --replace-fail '@NVIM_VERSION_PRERELEASE@' '-nightly+${neovim-src.shortRev or "dirty"}'
   '';
 


### PR DESCRIPTION
A wrong function was used.
This also influences what is shown at the start screen.

Before:
```
NVIM v0.11.0-dev
Build type: Release
LuaJIT 2.1.1713773202
Run "nvim -V1 -v" for more info
```

Now:
```
NVIM v0.11.0-nightly+fd05c7f
Build type: Release
LuaJIT 2.1.1713773202
Run "nvim -V1 -v" for more info
```