### PR TITLE
neovim: do not override libuv to avoid CPU usage problem on darwin

### DIFF
--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -41,7 +41,9 @@ let
 
   overrides = {
     libuv = pkgs.libuv.overrideAttrs {
-      src = deps.libuv;
+      # FIXME: overriding libuv casues high CPU usage on darwin
+      # https://github.com/nix-community/neovim-nightly-overlay/issues/538
+      # src = deps.libuv;
     };
     lua = pkgs.luajit;
     tree-sitter =


### PR DESCRIPTION
Overriding `libuv` seems to cause high CPU usage on darwin.
I have recently mistakenly re-enabled it (https://github.com/nix-community/neovim-nightly-overlay/pull/740) because I was expecting a build issue.

https://github.com/nix-community/neovim-nightly-overlay/issues/538
https://github.com/nix-community/neovim-nightly-overlay/issues/540

Fixes #741