### PR TITLE
chore: update tree-sitter cargo hash

### DIFF
--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -56,7 +56,7 @@ let
               // {
                 version = "bundled";
                 src = deps.treesitter;
-                cargoHash = "sha256-rjUn8F6WSxLQGrFzK23q4ClLePSpcMN2+i7rC02Fisk=";
+                cargoHash = "sha256-ie+/48dVU3r+tx/sQBWRIZEWSNWwMBANCqQLnv96JXs=";
               }
             );
         };


### PR DESCRIPTION
Update the cargo hash for tree-sitter package in neovim.nix to reflect the latest bundled version.

```
error: hash mismatch in fixed-output derivation '/nix/store/6fxizc4anvfg8s4bdi9n7yj38xsan6pm-tree-sitter-bundled-vendor.tar.gz.drv':
         specified: sha256-rjUn8F6WSxLQGrFzK23q4ClLePSpcMN2+i7rC02Fisk=
            got:    sha256-ie+/48dVU3r+tx/sQBWRIZEWSNWwMBANCqQLnv96JXs=
error: 1 dependencies of derivation '/nix/store/lkc6m7vrigfhz8qr5f175y66wrqr7hfs-tree-sitter-bundled.drv' failed to build
error: 1 dependencies of derivation '/nix/store/r598xaqk9x2qbqn8b15kvncpb7zb0n6j-neovim-unwrapped-nightly.drv' failed to build
error: 1 dependencies of derivation '/nix/store/b8ndm1qdm7zjji09jz7xs0snsm5pirl9-neovim-nightly.drv' failed to build
error: 1 dependencies of derivation '/nix/store/93vlzh4h8kkf0s67sgqlw4g7v4qpzffj-home-manager-applications.drv' failed to build
error: 1 dependencies of derivation '/nix/store/jyab67ppzn4dbc3d42sq9n9r1kcahfcm-home-manager-fonts.drv' failed to build
error: 1 dependencies of derivation '/nix/store/lgnc26r9sxvmvx23vxah70976sc8p0gs-home-manager-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/dzwcwb022h3virqbl0pykvm6vpmwayg5-home-manager-generation.drv' failed to build
```