### PR TITLE
fix neovim-debug by overriding disallowedRequisites

### DIFF
--- a/flake/packages/neovim-debug.nix
+++ b/flake/packages/neovim-debug.nix
@@ -8,8 +8,15 @@
   lua = pkgs.luajit;
 }).overrideAttrs
   (oa: {
-    dontStrip = true;
+    # Build neovim in debug mode
     NIX_CFLAGES_COMPILE = " -ggdb -Og";
     cmakeBuildType = "Debug";
-    disallowedReferences = [ ];
+
+    # Prevent nix from stripping debug symbols from the final binary
+    dontStrip = true;
+
+    # Do not explicitly disallow any paths to be referenced by the output
+    # By default, the neovim derivation disallows any reference to the compiler.
+    # https://github.com/NixOS/nixpkgs/blob/519502452f88c1e0b29ea6021fac0ce1640f4881/pkgs/by-name/ne/neovim-unwrapped/package.nix#L193
+    disallowedRequisites = [ ];
   })


### PR DESCRIPTION
Was probably broken since https://github.com/NixOS/nixpkgs/commit/9305ed35ec7f38c6fed16e9d6d0dcd788f007b4d.

Credits to @jonringer!
