### PR TITLE
fix neovim-* override interface

### DIFF
--- a/flake/packages/default.nix
+++ b/flake/packages/default.nix
@@ -24,19 +24,24 @@
             inherit lib pkgs neovim-dependencies;
           };
 
+          # NOTE: We use "import" instead of "callPackage" for neovim variants to keep the original "override" interface, ie, a user shall should be able to override neovim-debug like he overrides neovim-unwrapped
+          # This may change after https://github.com/NixOS/nixpkgs/pull/455805
           neovim = import ./neovim.nix {
             inherit (inputs) neovim-src;
             inherit lib pkgs neovim-dependencies;
             inherit (config.packages) tree-sitter;
           };
 
-          neovim-debug = pkgs.callPackage ./neovim-debug.nix {
+          neovim-debug = import ./neovim-debug.nix {
             inherit (config.packages) neovim;
+            inherit (pkgs) stdenv llvmPackages_latest;
+            inherit lib;
           };
 
-          neovim-developer = pkgs.callPackage ./neovim-developer.nix {
+          neovim-developer = import ./neovim-developer.nix {
             inherit (config.packages) neovim-debug;
             inherit (inputs) neovim-src;
+            inherit lib pkgs;
           };
         };
     };

--- a/flake/packages/neovim-developer.nix
+++ b/flake/packages/neovim-developer.nix
@@ -1,11 +1,7 @@
 {
   neovim-debug,
-  neovim-unwrapped,
   pkgs,
   lib,
-  stylua,
-  stdenv,
-  neovim-src,
   ...
 }:
 neovim-debug.overrideAttrs (oa: {
@@ -22,10 +18,10 @@ neovim-debug.overrideAttrs (oa: {
     ];
 
   nativeBuildInputs = oa.nativeBuildInputs ++ [
-    stylua
+    pkgs.stylua
   ];
 
-  doCheck = stdenv.isLinux;
+  doCheck = pkgs.stdenv.isLinux;
 
   # This package can be "failing" as soon as a memory leak is detected
   ignoreFailure = true;


### PR DESCRIPTION
we want users to be able to override neovim* packages (eg neovim-debug, neovim-developer)  like he/she overrides neovim-unwrapped

For instance I override home-manager's neovim package with:


```
  package = flakeSelf.packages.${pkgs.stdenv.hostPlatform.system}.neovim.override
      {
        # we want to take the luajit with our overlay of lua packages
        luajit = pkgs.luajit.override {
          packageOverrides = import ./lua-overrides.nix;
        };

      }
```


We use "import" instead of "callPackage" for neovim variants to keep the original "override" interface, ie,  This may change after https://github.com/NixOS/nixpkgs/pull/455805