### PR TITLE
fix(devShell): the current

### DIFF
--- a/flake/dev/devshells.nix
+++ b/flake/dev/devshells.nix
@@ -6,45 +6,33 @@
       lib,
       ...
     }:
-    {
-      devShells = {
-        default = pkgs.mkShell {
-          name = "neovim-developer-shell";
-          inputsFrom =
-            let
-              neovim-developer-ccache = config.packages.neovim-developer.overrideAttrs (oa: {
-                cmakeFlags = oa.cmakeFlags ++ [ (lib.cmakeFeature "CACHE_PRG" (lib.getExe pkgs.ccache)) ];
+    let
+      devShellFromNeovim =
+        pkg:
+        pkg.overrideAttrs (oa: {
+          cmakeFlags = config.packages.neovim-developer.cmakeFlags ++ [
+            (lib.cmakeFeature "CACHE_PRG" (lib.getExe pkgs.ccache))
+          ];
 
-                # avoid neovim-debug's patch to cmake.config/versiondef.h.in to minimize
-                # the noisy git diff when patching neovim
-                preConfigure = pkgs.neovim-unwrapped.preConfigure;
-              });
-            in
-            [ neovim-developer-ccache ];
+          # avoid neovim-debug's patch to cmake.config/versiondef.h.in to minimize
+          # the noisy git diff when patching neovim
+          preConfigure = pkgs.neovim-unwrapped.preConfigure;
 
-          packages = config.devShells.minimal.nativeBuildInputs ++ [
+          nativeBuildInputs = oa.nativeBuildInputs ++ [
             pkgs.stylua
             pkgs.include-what-you-use
             pkgs.clang-tools
           ];
 
-          shellHook = ''
-            export ASAN_SYMBOLIZER_PATH=${pkgs.llvm_18}/bin/llvm-symbolizer
-            export NVIM_PYTHON_LOG_LEVEL=DEBUG
-            export NVIM_LOG_FILE=/tmp/nvim.log
-
-            # ASAN_OPTIONS=detect_leaks=1
-            export ASAN_OPTIONS="log_path=./test.log:abort_on_error=1"
-
-            # treesitter parsers needed when running `make functionaltests`
-            mkdir -p runtime/parser
-            cp -f ${pkgs.vimPlugins.nvim-treesitter.builtGrammars.c}/parser runtime/parser/c.so
-          '';
-
           # Do not fail the hercules-ci because of this shell failing.
           # This often happens due to neovim-developer being broken.
           ignoreFailure = true;
-        };
+        });
+
+    in
+    {
+      devShells = {
+        default = devShellFromNeovim config.packages.neovim-developer;
 
         # Provide a devshell that can be used strictly for developing this flake.
         minimal = pkgs.mkShell.override { inherit (pkgs.llvmPackages_latest) stdenv; } {

--- a/flake/packages/neovim-debug.nix
+++ b/flake/packages/neovim-debug.nix
@@ -29,7 +29,7 @@
         echo "Detecting neovim runtime folder: VIMRUNTIME set to $VIMRUNTIME"
       fi
       echo "export NVIM_LOG_FILE to where you want to save the log"
-      export NVIM_LOG_FILE="$PWD/nvim.log"
+      export NVIM_LOG_FILE="/tmp/nvim.log"
     '';
 
     # Do not explicitly disallow any paths to be referenced by the output

--- a/flake/packages/neovim-developer.nix
+++ b/flake/packages/neovim-developer.nix
@@ -23,6 +23,13 @@ neovim-debug.overrideAttrs (oa: {
 
   doCheck = pkgs.stdenv.isLinux;
 
+  shellHook = ''
+    ${oa.shellHook or ""}
+    export ASAN_SYMBOLIZER_PATH=${pkgs.llvm_18}/bin/llvm-symbolizer
+
+    # ASAN_OPTIONS=detect_leaks=1
+    export ASAN_OPTIONS="log_path=./test.log:abort_on_error=1"
+  '';
   # This package can be "failing" as soon as a memory leak is detected
   ignoreFailure = true;
 })


### PR DESCRIPTION
current mkShell approach doesn't inherit cmakeFlags or cmake shell functions. Because I would like to expose possibly different dev configurations, I've added a function that takes as input a neovim derivation and modifies it to outputs a devShell.

It removes for instance the patch to hardcode "version" in cmake.config/versiondef.h.in,  to minimize the noisy git diff when patching neovim