### PR TITLE
fix overlay

### DIFF
--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -47,4 +47,16 @@ in
     substituteInPlace cmake.config/versiondef.h.in \
       --replace-fail '@NVIM_VERSION_PRERELEASE@' '-nightly+${neovim-src.shortRev or "dirty"}'
   '';
+
+  # Workaround: neovim renamed nvim.desktop to org.neovim.nvim.desktop,
+  # but the nixpkgs wrapper still references the old name.
+  # Create a compatibility copy until nixpkgs is updated.
+  # https://github.com/nix-community/neovim-nightly-overlay/issues/1244
+  postInstall =
+    (oa.postInstall or "")
+    + lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
+      if [ ! -e $out/share/applications/nvim.desktop ]; then
+        cp $out/share/applications/org.neovim.nvim.desktop $out/share/applications/nvim.desktop 2>/dev/null || true
+      fi
+    '';
 })


### PR DESCRIPTION
Neovim upstream renamed `nvim.desktop` to `org.neovim.nvim.desktop` (via https://github.com/neovim/neovim/pull/39031), but the nixpkgs wrapper still hardcodes `rm $out/share/applications/nvim.desktop` in its `postBuild`, causing the build to fail with `No such file or directory`.

This PR adds a `postInstall` phase to `neovim-unwrapped` that creates a compatibility copy of `org.neovim.nvim.desktop` as `nvim.desktop` on Linux.
This way the nixpkgs wrapper's `rm` and substitute commands find the file they expect.


Fixes #1244
