### PR TITLE
neovim: skip nixpkgs CVE-2026-11487 patch already in nightly

### DIFF
--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -42,6 +42,13 @@ in
   version = "${neovim-src.shortRev or "dirty"}";
   inherit src;
 
+  # Workaround: nixpkgs applies CVE-2026-11487.patch, but the fix is already
+  # part of nightly (neovim/neovim@f83e0dca), so it fails as already applied.
+  # Remove once nixpkgs drops the patch (NixOS/nixpkgs#530655).
+  patches = builtins.filter (patch: !lib.hasInfix "CVE-2026-11487" (toString patch)) (
+    oa.patches or [ ]
+  );
+
   preConfigure = ''
     ${oa.preConfigure}
     substituteInPlace cmake.config/versiondef.h.in \


### PR DESCRIPTION
## Description

nixpkgs currently applies `CVE-2026-11487.patch` to `neovim-unwrapped` (added in NixOS/nixpkgs@fcbcfa55dd). The nightly source already contains the upstream fix (neovim/neovim@f83e0dca), so the build fails with:

```
applying patch /nix/store/...-CVE-2026-11487.patch
patching file runtime/lua/vim/secure.lua
Reversed (or previously applied) patch detected!  Assume -R? [n]
Apply anyway? [n]
Skipping patch.
1 out of 1 hunk ignored -- saving rejects to file runtime/lua/vim/secure.lua.rej
```

This filters the patch out of the patch list inherited from nixpkgs. The workaround can be reverted once the pinned nixpkgs includes the 0.12.3 bump that removes the patch.

## Related PR

- NixOS/nixpkgs#530655 (`neovim-unwrapped: 0.12.2 -> 0.12.3`, removes the patch)

@GaetanLepage 