### PR TITLE
neovim: skip prebuilt treesitter wasm parser dep

### DIFF
--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -30,7 +30,12 @@ let
 
     treesitter-parsers =
       let
-        grammars = lib.filterAttrs (name: _: lib.hasPrefix "treesitter_" name) deps;
+        # Exclude prebuilt `treesitter_*_wasm` parsers (neovim/neovim#40304):
+        # they're .wasm binaries, not grammar sources, so buildGrammar can't
+        # unpack them. Unused here anyway, as nixpkgs builds without wasmtime.
+        grammars = lib.filterAttrs (
+          name: _: lib.hasPrefix "treesitter_" name && !lib.hasSuffix "_wasm" name
+        ) deps;
       in
       lib.mapAttrs' (
         name: value: lib.nameValuePair (lib.removePrefix "treesitter_" name) { src = value; }


### PR DESCRIPTION
## Problem

The nightly `flake.lock` update (#1313) fails to build:

```
unpacking source archive /nix/store/…-tree-sitter-lua.wasm
do not know how to unpack source archive /nix/store/…-tree-sitter-lua.wasm
```

## Root cause

neovim/neovim#40304 (merged 2026-06-19) added a new entry to `cmake.deps/deps.txt`:

```
TREESITTER_LUA_WASM_URL  …/tree-sitter-lua/releases/download/v0.5.0/tree-sitter-lua.wasm
TREESITTER_LUA_WASM_SHA256 df08a…
```

This is a **prebuilt** `.wasm` parser, not a grammar source. Upstream treats it specially — copied verbatim with `DOWNLOAD_NO_EXTRACT`, never built, and only when `ENABLE_WASMTIME` is set (off by default):

```cmake
if(USE_BUNDLED_TS_PARSERS AND ENABLE_WASMTIME)
  ExternalProject_Add(treesitter_lua_wasm
    DOWNLOAD_NO_EXTRACT TRUE
    CONFIGURE_COMMAND "" BUILD_COMMAND ""
    INSTALL_COMMAND … copy tree-sitter-lua.wasm …/parser/lua.wasm)
endif()
```

`neovim-dependencies.nix` parses every `*_{URL,SHA256}` pair, so it produces a `treesitter_lua_wasm` fetchurl. `neovim.nix` then selects everything with the `treesitter_` prefix and passes it to nixpkgs as a grammar `src`, which runs `tree-sitter.buildGrammar` → `unpackPhase` tries to untar the `.wasm` → fails.

## Fix

Exclude `treesitter_*_wasm` entries from the grammar set. nixpkgs `neovim-unwrapped` builds without wasmtime (`ENABLE_WASMTIME` off, no wasmtime in `buildInputs`), so the wasm parser would be unused even if it built — nothing functional is lost.

## Verification

`nix eval` of `treesitter-parsers` against the #1313 neovim rev (`6284c11`):

- before: `[ "c" "lua" "lua_wasm" "markdown" "markdown_inline" "query" "vim" "vimdoc" ]`
- after: `[ "c" "lua" "markdown" "markdown_inline" "query" "vim" "vimdoc" ]`

`lua_wasm` is dropped; the real grammar set is unchanged from before the regression.

Unblocks #1313.
