### PR TITLE
fix(neovim): drop stale patch, support wasm parsers

### DIFF
--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -54,6 +54,23 @@ in
     oa.patches or [ ]
   );
 
+  postPatch =
+    # NOTE: Upstream nixpkgs needed to loosen requirements on stable release of neovim.
+    # Nightly already has support for loosened requirements.
+    lib.replaceStrings
+      [
+        ''
+          substituteInPlace src/nvim/CMakeLists.txt \
+            --replace-fail \
+              'find_package(Wasmtime 36.0.6 EXACT REQUIRED)' \
+              'find_package(Wasmtime REQUIRED)'
+        ''
+      ]
+      [
+        ""
+      ]
+      (oa.postPatch or "");
+
   preConfigure = ''
     ${oa.preConfigure}
     substituteInPlace cmake.config/versiondef.h.in \

--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -9,6 +9,7 @@
 let
   src = neovim-src;
   deps = neovim-dependencies;
+  treesitterDeps = lib.filterAttrs (name: _: lib.hasPrefix "treesitter_" name) deps;
 
   # The following overrides will only take effect for linux hosts
   linuxOnlyOverrides = lib.optionalAttrs pkgs.stdenv.isLinux {
@@ -29,17 +30,11 @@ let
     inherit tree-sitter;
 
     treesitter-parsers =
-      let
-        # Exclude prebuilt `treesitter_*_wasm` parsers (neovim/neovim#40304):
-        # they're .wasm binaries, not grammar sources, so buildGrammar can't
-        # unpack them. Unused here anyway, as nixpkgs builds without wasmtime.
-        grammars = lib.filterAttrs (
-          name: _: lib.hasPrefix "treesitter_" name && !lib.hasSuffix "_wasm" name
-        ) deps;
-      in
+      # `treesitter_*` deps are grammar sources. `treesitter_*_wasm` deps are
+      # prebuilt parser binaries and get installed separately when supported.
       lib.mapAttrs' (
         name: value: lib.nameValuePair (lib.removePrefix "treesitter_" name) { src = value; }
-      ) grammars;
+      ) (lib.filterAttrs (name: _: !lib.hasSuffix "_wasm" name) treesitterDeps);
   }
   // linuxOnlyOverrides;
 in
@@ -73,6 +68,15 @@ in
 
   preConfigure = ''
     ${oa.preConfigure}
+  ''
+  + lib.optionalString (lib.any (lib.hasPrefix "-DENABLE_WASMTIME") (oa.cmakeFlags or [ ])) (
+    lib.concatStrings (
+      lib.mapAttrsToList (name: value: ''
+        install -Dm444 ${value} $out/lib/nvim/parser/${lib.removeSuffix "_wasm" (lib.removePrefix "treesitter_" name)}.wasm
+      '') (lib.filterAttrs (name: _: lib.hasSuffix "_wasm" name) treesitterDeps)
+    )
+  )
+  + ''
     substituteInPlace cmake.config/versiondef.h.in \
       --replace-fail '@NVIM_VERSION_PRERELEASE@' '-nightly+${neovim-src.shortRev or "dirty"}'
   '';

--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -10,6 +10,8 @@ let
   src = neovim-src;
   deps = neovim-dependencies;
   treesitterDeps = lib.filterAttrs (name: _: lib.hasPrefix "treesitter_" name) deps;
+  wasmParserDeps = lib.filterAttrs (name: _: lib.hasSuffix "_wasm" name) treesitterDeps;
+  hasWasmCmakeFlag = cmakeFlags: lib.any (lib.hasPrefix "-DENABLE_WASMTIME") cmakeFlags;
 
   # The following overrides will only take effect for linux hosts
   linuxOnlyOverrides = lib.optionalAttrs pkgs.stdenv.isLinux {
@@ -69,11 +71,11 @@ in
   preConfigure = ''
     ${oa.preConfigure}
   ''
-  + lib.optionalString (lib.any (lib.hasPrefix "-DENABLE_WASMTIME") (oa.cmakeFlags or [ ])) (
+  + lib.optionalString (hasWasmCmakeFlag oa.cmakeFlags) (
     lib.concatStrings (
       lib.mapAttrsToList (name: value: ''
         install -Dm444 ${value} $out/lib/nvim/parser/${lib.removeSuffix "_wasm" (lib.removePrefix "treesitter_" name)}.wasm
-      '') (lib.filterAttrs (name: _: lib.hasSuffix "_wasm" name) treesitterDeps)
+      '') wasmParserDeps
     )
   )
   + ''
@@ -87,6 +89,15 @@ in
   # https://github.com/nix-community/neovim-nightly-overlay/issues/1244
   postInstall =
     (oa.postInstall or "")
+    # Neovim's WASM tests compare native and WASM lua parsers, so remove
+    # duplicate native runtime parsers only after checks run.
+    + lib.optionalString (hasWasmCmakeFlag oa.cmakeFlags) (
+      lib.concatStrings (
+        lib.mapAttrsToList (name: _: ''
+          rm -f $out/lib/nvim/parser/${lib.removeSuffix "_wasm" (lib.removePrefix "treesitter_" name)}.so
+        '') wasmParserDeps
+      )
+    )
     + lib.optionalString pkgs.stdenv.hostPlatform.isLinux ''
       if [ ! -e $out/share/applications/nvim.desktop ]; then
         cp $out/share/applications/org.neovim.nvim.desktop $out/share/applications/nvim.desktop 2>/dev/null || true


### PR DESCRIPTION
Nightly already carries compatible Wasmtime CMake handling, so the stable nixpkgs substitution must not run against the nightly source.

Split prebuilt wasm parser artifacts from grammar sources and install them during configure so Neovim wasm tests can load them.

Neovim tests require native parsers to compare against WASM equivalents.
To prevent shipping duplicates, this deletes native parsers that have WASM replacements after checks pass.