### PR TITLE
fix: shorter stdpath('run') inside darwin sandbox

### DIFF
--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -68,6 +68,13 @@ in
       ]
       (oa.postPatch or "");
 
+  # Setting XDG_RUNTIME_DIR expliclity to TMPDIR prevents stdpath('run') from
+  # falling back to '$TMPDIR/nvim.<user>/<rand>' which (adding cmake 'Xtest_tmpdir_<suite')
+  # makes functionaltest fail due to socket path being too long (104 bytes on darwin)
+  preCheck = (oa.preCheck or "") + ''
+    export XDG_RUNTIME_DIR="$(mktemp -d)"
+  '';
+
   preConfigure = ''
     ${oa.preConfigure}
   ''


### PR DESCRIPTION
fixes checkPhase issues after https://github.com/neovim/neovim/pull/40625

closes https://github.com/nix-community/neovim-nightly-overlay/issues/1334