### PR TITLE
chore(packages): remove evaluation warning

### DIFF
--- a/flake/packages/neovim-debug.nix
+++ b/flake/packages/neovim-debug.nix
@@ -6,7 +6,7 @@
   ...
 }:
 (neovim.override {
-  stdenv = if stdenv.isLinux then llvmPackages_latest.stdenv else stdenv;
+  stdenv = if stdenv.hostPlatform.isLinux then llvmPackages_latest.stdenv else stdenv;
 }).overrideAttrs
   (oa: {
     pname = "${oa.pname}-debug";

--- a/flake/packages/neovim-developer.nix
+++ b/flake/packages/neovim-developer.nix
@@ -11,7 +11,7 @@ neovim-debug.overrideAttrs (oa: {
     ++ [
       (lib.cmakeBool "ENABLE_LTO" false)
     ]
-    ++ lib.optionals pkgs.stdenv.isLinux [
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
       # https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
       # https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports
       (lib.cmakeBool "ENABLE_ASAN_UBSAN" true)
@@ -21,7 +21,7 @@ neovim-debug.overrideAttrs (oa: {
     pkgs.stylua
   ];
 
-  doCheck = pkgs.stdenv.isLinux;
+  doCheck = pkgs.stdenv.buildPlatform.isLinux;
 
   shellHook = ''
     ${oa.shellHook or ""}

--- a/flake/packages/neovim.nix
+++ b/flake/packages/neovim.nix
@@ -14,7 +14,7 @@ let
   hasWasmCmakeFlag = cmakeFlags: lib.any (lib.hasPrefix "-DENABLE_WASMTIME") cmakeFlags;
 
   # The following overrides will only take effect for linux hosts
-  linuxOnlyOverrides = lib.optionalAttrs pkgs.stdenv.isLinux {
+  linuxOnlyOverrides = lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
     gettext = pkgs.gettext.overrideAttrs {
       # FIXME: nixpkgs' gettext is now at version 0.22.5 whereas neovim's is pinned at 0.20.5
       # Overriding the source leads to a build error of gettext.


### PR DESCRIPTION
The `stdenv.isLinux` is deprecated on newer nixpkgs revisions.